### PR TITLE
Fix #1 - Multi-line stabby lambdas:

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -13,6 +13,10 @@ Metrics/LineLength:
 # To prevent user defaults on double quotes
 StringLiterals:
   EnforcedStyle: single_quotes
+  
+# Allow multi-line stabby lambdas
+Style/Lambda:
+  Enabled: false
 
 # Load Rails cops
 AllCops:


### PR DESCRIPTION
Unfortunately, this will also disable parentheses checks and
use of stabby lambdas on a single-line. I think that's rather
obvious, however.

See https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/style/lambda.rb
