### PR TITLE
Don't warn about missing frozen string literal comment

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -2,6 +2,10 @@
 Documentation:
   Enabled: false
 
+# Don't warn about frozen string literal comment
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: never
+
 # No preference for nested or compact class / module defenition
 ClassAndModuleChildren:
   Enabled: false


### PR DESCRIPTION
Because we don't want to add a comment to every single ruby file we write.
