### PR TITLE
Target ruby 2.3

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -34,4 +34,4 @@ Rails:
 AllCops:
   Exclude:
     - db/schema.rb
-
+  TargetRubyVersion: 2.3


### PR DESCRIPTION
We should target 2.3. This will prevent 2.3-specific code from raising any problems.
