### PR TITLE
Require rubocop rails

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-rails
+
 # Missing top-level %s documentation comment is ok for simple classes
 Documentation:
   Enabled: false


### PR DESCRIPTION
Required in my case after installing appropriate gems (rubocop, rubocop-rails). Otherwise I receive errors.