### PR TITLE
Enable pending cops

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -39,6 +39,15 @@ Style/FormatStringToken:
 Style/FormatString:
   Enabled: false
 
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
 # Don't test auto generated files
 AllCops:
   Exclude:


### PR DESCRIPTION
Got this warning when running from a fresh install.

```
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Style/HashEachMethods (0.80)
 - Style/HashTransformKeys (0.80)
 - Style/HashTransformValues (0.80)
For more information: https://docs.rubocop.org/en/latest/versioning/
```